### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl"        : "6.*",
     "name"        : "Plosurin",
+    "license"     : "Artistic-2.0",
     "version"     : "0.02",
     "description" : "Perl 6 implementation of Closure Templates",
     "provides"    : {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license