### PR TITLE
Remove the most obvious bitrot

### DIFF
--- a/lib/Plosurin.pm
+++ b/lib/Plosurin.pm
@@ -67,7 +67,7 @@ grammar Plosurin::Template {
     rule command_import {
         'import'  <attribute> ** 1..2 }
     rule expression { [ \w+ ['=='||'<'||'>'] \w+ || <variable>] }
-    rule expression_list { [\w+] ** ',' }
+    rule expression_list { [\w+]* %% ',' }
     token variable { '$' \w+ }
 #    rule pair  { <string> ':'  <value>     }
     rule attribute { (\w+) '=' '"' (<-["]>+) '"' }

--- a/lib/Plosurin.pm
+++ b/lib/Plosurin.pm
@@ -70,7 +70,7 @@ grammar Plosurin::Template {
     rule expression_list { [\w+] ** ',' }
     token variable { '$' \w+ }
 #    rule pair  { <string> ':'  <value>     }
-    rule attribute { (\w+) '=' '"' (<-['"']>+) '"' }
+    rule attribute { (\w+) '=' '"' (<-["]>+) '"' }
 
 }
 

--- a/t/t01.t
+++ b/t/t01.t
@@ -27,6 +27,6 @@ my @lexer_tests =
 
 for @lexer_tests -> $template, $check, $test_name {
     my $res = Plosurin::Template.parse($template,  :actions(Plosurin::TActions.new));
-    is_deeply [ $/.ast».dumper],$check, $test_name ?? $test_name !! $template;
+    is-deeply [ $/.ast».dumper],$check, $test_name ?? $test_name !! $template;
 }
 

--- a/t/t02.t
+++ b/t/t02.t
@@ -32,5 +32,5 @@ my $txt= '{namespace rname.sample}
 
 my $res = Plosurin::Grammar.parse($txt, :actions(Plosurin::Actions.new ));
 ok $res, 'grammar';
-is_deeply [$/.ast.values».WHAT».perl], ["Template", "Template", "Template"], 'objects';
+is-deeply [$/.ast.values».WHAT».perl], ["Template", "Template", "Template"], 'objects';
 


### PR DESCRIPTION
Fix subtle changes in Rakudo Perl 6 that have become syntax errors and
for which I could find a clear answer.